### PR TITLE
feat: store openai api key in an env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ pip install -r requirements.txt
 ``` 
 
 
-3. Create a `.TOKEN.txt` file in the root directory of the project and add your OpenAI API key.
+3. Add your OpenAI API key.
 
 ```bash
-echo "your-openai-api-key" > .TOKEN.txt
+export OPENAI_API_KEY="your-openai-api-key"
 
 ```
 

--- a/decomposer.py
+++ b/decomposer.py
@@ -9,10 +9,7 @@ import os
 def generate_code(prompt):
     # ----------------- CALL OPEN AI
 
-    #keyFile = open('/Users/adammcmurchie/code/tools/davinci/.KEY.txt','r')
-    keyFile = open('.TOKEN.txt','r')
-    openai.api_key    = keyFile.read()
-
+    openai.api_key = os.environ["OPENAI_API_KEY"]
     availableResponses   = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=[{"role": "system", "content": prompt}])
     currentResponse = availableResponses['choices'][0]['message']['content'].lstrip()
     return currentResponse


### PR DESCRIPTION
This should allow users to store their key in an env var instead of a txt file.